### PR TITLE
Fix/Replaces pluralize with inflector, fails to singularize resource PriceQuizzes to priceQuiz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "ember-cli-string-utils": "^1.1.0",
         "escape-string-regexp": "^4.0.0",
         "express": "^4.18.1",
+        "inflection": "^1.13.4",
         "jsonwebtoken": "^8.5.1",
         "knex": "^2.3.0",
         "koa": "2.13.4",
         "koa-body": "^5.0.0",
         "koa-compose": "^4.1.0",
-        "pluralize": "^8.0.0",
         "ws": "^8.8.1"
       },
       "devDependencies": {
@@ -4162,6 +4162,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "engines": [
+        "node >= 0.4.0"
+      ]
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6207,14 +6215,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -11221,6 +11221,11 @@
       "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
       "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
     },
+    "inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -12788,11 +12793,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "koa": "2.13.4",
     "koa-body": "^5.0.0",
     "koa-compose": "^4.1.0",
-    "pluralize": "^8.0.0",
+    "inflection": "^1.13.4",
     "ws": "^8.8.1"
   },
   "devDependencies": {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,12 +1,4 @@
-import { plural, singular } from "pluralize";
-
-function pluralize(word = "") {
-  return plural(word);
-}
-
-function singularize(word = "") {
-  return singular(word);
-}
+import { pluralize, singularize } from "inflection";
 
 export { camelize, capitalize, classify, dasherize, decamelize, underscore } from "ember-cli-string-utils";
 export { pluralize, singularize };


### PR DESCRIPTION
**Scopes:**
- 🐞 Fix

# Summary
Given a resource name called "PriceQuiz", an endpoint "/priceQuizzes" was expected, but due to the singularize method of the `pluralize` library, it produces the string `priceQuizz` instead.

## Quick test app
```js
console.log("----------------- Using Pluralize Package -------------------------")

var pluralize = require('pluralize')
console.log(`Pluralize "quiz" -> ${pluralize('quiz')}`)
console.log(`Singularize "quizzes" -> ${pluralize.singular('quizzes')}`)
console.log(`Pluralize "priceQuiz" -> ${pluralize('priceQuiz')}`)
console.log(`Singularize "priceQuizzes" -> ${pluralize.singular('priceQuizzes')}`)

console.log("----------------- Using Inflection Package -------------------------")

var inflection = require( 'inflection' );
console.log(`Pluralize "quiz" -> ${inflection.pluralize('quiz')}`)
console.log(`Singularize "quizzes" -> ${inflection.singularize('quizzes')}`)
console.log(`Pluralize "priceQuiz" -> ${inflection.pluralize('priceQuiz')}`)
console.log(`Singularize "priceQuizzes" -> ${inflection.singularize('priceQuizzes')}`)
```

## Results
```
----------------- Using Pluralize Package -------------------------
Pluralize "quiz" -> quizzes
Singularize "quizzes" -> quiz
Pluralize "priceQuiz" -> priceQuizs
Singularize "priceQuizzes" -> priceQuizz

----------------- Using Inflection Package -------------------------
Pluralize "quiz" -> quizzes
Singularize "quizzes" -> quiz
Pluralize "priceQuiz" -> priceQuizzes
Singularize "priceQuizzes" -> priceQuiz
```

# Digging into the main issue
According to https://github.com/plurals/pluralize/issues/177, the library produces several inconsistencies across a large number of english words. Several other individual issues might point out that the library fails on a lot more words.

# Proposal
Use Inflection (https://github.com/dreamerslab/node.inflection) as an alternative to pluralize.